### PR TITLE
Optimize lessons list performance

### DIFF
--- a/backend/backend/modules/courses/schemas.py
+++ b/backend/backend/modules/courses/schemas.py
@@ -9,6 +9,14 @@ class ListCoursesCourseData(Course):
     lessons_count: int
 
 
+class ListLessonsForCourseData(BaseModel):
+    id: int
+    name: str
+    duration: int
+    lesson_index: int
+    course_id: int
+
+
 class CreateNewCourseData(BaseModel):
     name: str
     image: str

--- a/backend/backend/modules/courses/services.py
+++ b/backend/backend/modules/courses/services.py
@@ -1,13 +1,15 @@
-from typing import Optional
+from typing import List, Optional
 
 from backend.modules.lessons.repository import LessonsRepository
 from fastapi import Depends, Header, Path, Response
+from pydantic.tools import parse_obj_as
 
 from .repository import CoursesRepository
 from .schemas import (
     CreateNewCourseData,
     IndexCoursesFromListData,
     ListCoursesCourseData,
+    ListLessonsForCourseData,
     UpdateCourseData,
 )
 
@@ -76,7 +78,7 @@ async def list_lessons_for_course(
 ):
     lessons = await lessons_repository.list_by_course_id(course_id)
 
-    return lessons
+    return parse_obj_as(List[ListLessonsForCourseData], lessons)
 
 
 async def create_course(

--- a/backend/backend/modules/lessons/repository.py
+++ b/backend/backend/modules/lessons/repository.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Iterable, List, Mapping
+from typing import Iterable, List, Mapping, Optional
 
 from backend.shared.database.connection import (
     DatabaseConnection,
@@ -119,6 +119,11 @@ class LessonsRepository:
         )
 
         return parse_obj_as(List[Lesson], lessons)
+
+    async def find_one_by_id(self, id: int) -> Optional[Lesson]:
+        lesson = self.db.query(LessonDAO).filter(LessonDAO.id == id).first()
+
+        return Lesson.from_orm(lesson)
 
     async def count_lessons_per_course(self) -> Mapping[int, int]:
         counts = self.db.execute(

--- a/backend/backend/modules/lessons/routes.py
+++ b/backend/backend/modules/lessons/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from .services import create_new_lesson, update_lesson
+from .services import create_new_lesson, show_lesson_details, update_lesson
 
 lessons_router = APIRouter(prefix="/lessons")
 
@@ -9,3 +9,5 @@ lessons_router.add_api_route("/", create_new_lesson, methods=["POST"], status_co
 lessons_router.add_api_route(
     "/{lesson_id}", update_lesson, methods=["PUT"], status_code=204
 )
+
+lessons_router.add_api_route("/{lesson_id}", show_lesson_details, methods=["GET"])

--- a/backend/backend/modules/lessons/services.py
+++ b/backend/backend/modules/lessons/services.py
@@ -5,6 +5,15 @@ from .repository import LessonsRepository
 from .schemas import CreateNewLessonData, UpdateLessonData
 
 
+async def show_lesson_details(
+    lesson_id: int = Path(...),
+    lessons_repository: LessonsRepository = Depends(),
+):
+    lesson = await lessons_repository.find_one_by_id(lesson_id)
+
+    return lesson
+
+
 async def create_new_lesson(
     lesson_data: CreateNewLessonData,
     lessons_repository: LessonsRepository = Depends(),

--- a/mobile/src/hooks/lessons.tsx
+++ b/mobile/src/hooks/lessons.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useReducer,
 } from 'react';
 import useSWR from 'swr';
@@ -10,14 +11,22 @@ import { useCourses } from './courses';
 
 import api from '../services/api';
 
-interface ILessonResponseData {
+interface ILessonsListResponseData {
   id: number;
   name: string;
   duration: number;
+  lesson_index: number;
+  course_id: number;
+}
+
+interface ILessonDetailsResponseData {
+  id: number;
+  name: string;
+  duration: number;
+  lesson_index: number;
   description: string;
   video_id: string;
   thumbnail_url: string;
-  lesson_index: number;
 }
 
 interface ILessonData {
@@ -29,6 +38,12 @@ interface ILessonData {
   thumbnail_url: string;
   isCompleted?: boolean;
   videoId: string;
+}
+
+interface ILessonDetailsData {
+  description: string;
+  thumbnail_url: string;
+  video_id: string;
 }
 
 interface LessonsContextData {
@@ -44,6 +59,7 @@ type SelectedLessonReducer = React.Reducer<
   | { type: 'SET_ID'; id: number }
   | { type: 'SET_NEXT' }
   | { type: 'SET_PREVIOUS' }
+  | { type: 'SET_DETAILS'; details: ILessonDetailsData }
 >;
 
 const LessonsContext = createContext<LessonsContextData>(
@@ -53,20 +69,20 @@ const LessonsContext = createContext<LessonsContextData>(
 export const LessonsProvider: React.FC = ({ children }) => {
   const { selectedCourse: course } = useCourses();
 
-  const { data: lessons } = useSWR(
+  const { data: lessons } = useSWR<ILessonData[]>(
     course ? `courses/${course.id}/lessons` : null,
     async (url: string) => {
-      const response = await api.get<ILessonResponseData[]>(url);
+      const response = await api.get<ILessonsListResponseData[]>(url);
 
       return response.data.map(lesson => {
         return {
           id: lesson.id,
           name: lesson.name,
           duration: lesson.duration,
-          description: lesson.description,
           lessonIndex: lesson.lesson_index,
-          videoId: lesson.video_id,
-          thumbnail_url: lesson.thumbnail_url,
+          videoId: '',
+          description: '',
+          thumbnail_url: '',
         };
       });
     },
@@ -114,6 +130,15 @@ export const LessonsProvider: React.FC = ({ children }) => {
             selectedLesson: previous || null,
           };
         }
+        case 'SET_DETAILS': {
+          return {
+            ...state,
+            selectedLesson: state.selectedLesson && {
+              ...state.selectedLesson,
+              ...action.details,
+            },
+          };
+        }
         default:
           return state;
       }
@@ -132,6 +157,30 @@ export const LessonsProvider: React.FC = ({ children }) => {
   const setPreviousLesson = useCallback(() => {
     selectedLessonDispatch({ type: 'SET_PREVIOUS' });
   }, []);
+
+  const setLessonDetails = useCallback(
+    ({ description, thumbnail_url, video_id }: ILessonDetailsData) => {
+      selectedLessonDispatch({
+        type: 'SET_DETAILS',
+        details: { description, thumbnail_url, video_id },
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (selectedLesson && !selectedLesson.description) {
+      api
+        .get<ILessonDetailsResponseData>(`lessons/${selectedLesson.id}`)
+        .then(({ data }) => {
+          setLessonDetails({
+            description: data.description,
+            thumbnail_url: data.thumbnail_url,
+            video_id: data.video_id,
+          });
+        });
+    }
+  }, [selectedLesson, setLessonDetails]);
 
   return (
     <LessonsContext.Provider

--- a/mobile/src/hooks/lessons.tsx
+++ b/mobile/src/hooks/lessons.tsx
@@ -34,10 +34,10 @@ interface ILessonData {
   name: string;
   duration: number;
   description: string;
+  video_id: string;
   lessonIndex: number;
   thumbnail_url: string;
   isCompleted?: boolean;
-  videoId: string;
 }
 
 interface ILessonDetailsData {
@@ -80,7 +80,7 @@ export const LessonsProvider: React.FC = ({ children }) => {
           name: lesson.name,
           duration: lesson.duration,
           lessonIndex: lesson.lesson_index,
-          videoId: '',
+          video_id: '',
           description: '',
           thumbnail_url: '',
         };

--- a/mobile/src/pages/LessonDetail/index.tsx
+++ b/mobile/src/pages/LessonDetail/index.tsx
@@ -13,6 +13,7 @@ import {
   MainContent,
   MainScrollable,
   VideoPlaceholder,
+  ThumbnailPlaceholderBackground,
   Title,
   InfoContainer,
   Index,
@@ -25,6 +26,8 @@ import {
   NextLessonButton,
   NextLessonButtonText,
   PlayButtonPressable,
+  DescriptionPlaceholderContainer,
+  DescriptionPlaceholderText,
 } from './styles';
 
 import logoImg from '../../assets/images/logo-small.png';
@@ -71,15 +74,21 @@ const LessonDetail: React.FC = () => {
       </Header>
 
       <MainContent>
-        <PlayButtonPressable onPress={handleNavigateToVideo}>
-          <VideoPlaceholder
-            source={{ uri: lesson.thumbnail_url }}
-            resizeMode="cover"
-            resizeMethod="resize"
-          >
+        {lesson.thumbnail_url ? (
+          <PlayButtonPressable onPress={handleNavigateToVideo}>
+            <VideoPlaceholder
+              source={{ uri: lesson.thumbnail_url }}
+              resizeMode="cover"
+              resizeMethod="resize"
+            >
+              <Feather name="play-circle" size={54} color="#fff" />
+            </VideoPlaceholder>
+          </PlayButtonPressable>
+        ) : (
+          <ThumbnailPlaceholderBackground>
             <Feather name="play-circle" size={54} color="#fff" />
-          </VideoPlaceholder>
-        </PlayButtonPressable>
+          </ThumbnailPlaceholderBackground>
+        )}
 
         <MainScrollable>
           <Title>{lesson.name}</Title>
@@ -96,21 +105,31 @@ const LessonDetail: React.FC = () => {
             </DurationContainer>
           </InfoContainer>
 
-          <Description>{lesson.description}</Description>
+          {!lesson.description ? (
+            <DescriptionPlaceholderContainer>
+              <DescriptionPlaceholderText>
+                Carregando descrição...
+              </DescriptionPlaceholderText>
+            </DescriptionPlaceholderContainer>
+          ) : (
+            <>
+              <Description>{lesson.description}</Description>
 
-          <BottomButtonsContainer>
-            <PreviousLessonButton onPress={handleNavigateToPreviousLesson}>
-              <Feather name="arrow-left" color="#ff6680" size={20} />
+              <BottomButtonsContainer>
+                <PreviousLessonButton onPress={handleNavigateToPreviousLesson}>
+                  <Feather name="arrow-left" color="#ff6680" size={20} />
 
-              <PreviousLessonButtonText>Anterior</PreviousLessonButtonText>
-            </PreviousLessonButton>
+                  <PreviousLessonButtonText>Anterior</PreviousLessonButtonText>
+                </PreviousLessonButton>
 
-            <NextLessonButton onPress={handleNavigateToNextLesson}>
-              <NextLessonButtonText>Próxima</NextLessonButtonText>
+                <NextLessonButton onPress={handleNavigateToNextLesson}>
+                  <NextLessonButtonText>Próxima</NextLessonButtonText>
 
-              <Feather name="arrow-right" color="#ffffff" size={20} />
-            </NextLessonButton>
-          </BottomButtonsContainer>
+                  <Feather name="arrow-right" color="#ffffff" size={20} />
+                </NextLessonButton>
+              </BottomButtonsContainer>
+            </>
+          )}
         </MainScrollable>
       </MainContent>
     </Container>

--- a/mobile/src/pages/LessonDetail/styles.ts
+++ b/mobile/src/pages/LessonDetail/styles.ts
@@ -38,6 +38,17 @@ export const VideoPlaceholder = styled.ImageBackground.attrs({
   align-items: center;
 `;
 
+export const ThumbnailPlaceholderBackground = styled.View`
+  background: #333;
+
+  height: 210px;
+  justify-content: center;
+  align-items: center;
+
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+`;
+
 export const Title = styled.Text`
   font-family: ${'rubik400'};
   margin-bottom: 16px;
@@ -79,6 +90,19 @@ export const Description = styled.Text`
   font-size: 15px;
   line-height: 25px;
   margin-bottom: 24px;
+`;
+
+export const DescriptionPlaceholderContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  margin: 56px 0;
+`;
+
+export const DescriptionPlaceholderText = styled.Text`
+  font-family: ${'roboto400'};
+  color: #3d3d4c;
+  font-size: 18px;
 `;
 
 export const BottomButtonsContainer = styled.View`

--- a/mobile/src/pages/PlayVideo/index.tsx
+++ b/mobile/src/pages/PlayVideo/index.tsx
@@ -36,7 +36,7 @@ const PlayVideo: React.FC = () => {
         scrollEnabled={false}
         allowsBackForwardNavigationGestures={Platform.OS === 'ios'}
         source={{
-          uri: `https://youtube.com/embed/${lesson?.videoId}`,
+          uri: `https://youtube.com/embed/${lesson?.video_id}`,
         }}
       />
     </Container>


### PR DESCRIPTION
When opening the Lessons screen, the app loads all the lessons for the given course into state. Some of the lessons descriptions are really long texts and hinder the performance when navigating from Home or MyCourses into Lessons.

To avoid it, it's best to load the description and other lesson details only when the LessonDetail screen is accessed for a given lesson.